### PR TITLE
Remove use of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,7 +31,3 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       commit_message: 'Update Stanford data dump'
       branch: data-updates
-
-  env:
-    # This is necessary in order to push a commit to the repo
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged


### PR DESCRIPTION
According to https://github.com/actions/checkout#usage a token is already passed (and saved during the workflow run) through the checkout, so our workflow looks like it should already have that access.

The thing that I was thinking of was if we needed to pass the token to a custom action, but it looks like the action we're using to commit is just using bash, so perhaps it picks up that token in the git config? (I suppose we'll see).  Their [action.yml](https://github.com/stefanzweifel/git-auto-commit-action/blob/master/action.yml) at least does not indicate that they take a token as an input anyway.