### PR TITLE
Update GitHub Actions build permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'Update Stanford data dump'
+          commit_author: 'GitHub Actions <41898282+github-actions[bot]@users.noreply.github.com>'
           branch: data-updates
           push_options: '--force'
       - name: pull-request

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - run: git checkout -b data-updates

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
       - run: bundle exec rake
         env:
           STACKS_TOKEN: ${{ secrets.STACKS_TOKEN }}
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'Update Stanford data dump'
           branch: data-updates


### PR DESCRIPTION
The most recent run failed, apparently due to a permissions issue.

- Give the GitHub Actions build more permissions for opening PRs
- Use the latest version of the auto-commit action
- Attribute the data dump updates to GitHub instead of the last committer
